### PR TITLE
fix: Adiciona mapeamentos para ResponseTravelPackageDTO

### DIFF
--- a/Viagium/ProfileAutoMapper/EntitiesMappingDTO.cs
+++ b/Viagium/ProfileAutoMapper/EntitiesMappingDTO.cs
@@ -60,6 +60,12 @@ namespace Viagium.ProfileAutoMapper
                 .ForMember(dest => dest.DestinationAddress, opt => opt.MapFrom(src => src.DestinationAddress))
                 .ForMember(dest => dest.CreatedBy, opt => opt.MapFrom(src => src.UserId));
             CreateMap<TravelPackageHistory, TravelPackageHistoryDTO>();
+            CreateMap<ResponseTravelPackageDTO, UpdateTravelPackageFormDTO>().ReverseMap();
+            CreateMap<UpdateTravelPackageFormDTO, ResponseTravelPackageDTO>()
+                .ForMember(dest => dest.Hotels, opt => opt.Ignore())
+                .ForMember(dest => dest.PackageSchedule, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.IsActive, opt => opt.Ignore());
             CreateMap<UserUpdateDto, Viagium.Models.User>()
                 .ForMember(dest => dest.DocumentNumber, opt => opt.Ignore())
                 .ForMember(dest => dest.Role, opt => opt.Ignore())


### PR DESCRIPTION
Novos mapeamentos foram implementados no namespace `Viagium.ProfileAutoMapper` no arquivo `EntitiesMappingDTO.cs`. Foram criados os mapeamentos entre `ResponseTravelPackageDTO` e `UpdateTravelPackageFormDTO`, incluindo um mapeamento reverso. Além disso, várias propriedades em `UpdateTravelPackageFormDTO` foram configuradas para serem ignoradas durante o mapeamento, como `Hotels`, `PackageSchedule`, `CreatedAt` e `IsActive`.