### PR TITLE
fix: Corrige loop infinito em atualização de reservas

### DIFF
--- a/Viagium/Services/ReservationService.cs
+++ b/Viagium/Services/ReservationService.cs
@@ -98,8 +98,8 @@ namespace Viagium.Services
                     await _unitOfWork.RoomRepository.UpdateAsync(availableRoom);
                 }
 
-                // ✅ NOVO: Atualizar o número de pessoas confirmadas no TravelPackage
-                await UpdateConfirmedPeopleCountAsync(createReservationDto.TravelPackageId);
+                // ✅ CORREÇÃO: Removido a chamada problemática que pode causar loop infinito
+                // await UpdateConfirmedPeopleCountAsync(createReservationDto.TravelPackageId);
 
                 return dto;
 
@@ -252,7 +252,7 @@ namespace Viagium.Services
                     throw new InvalidOperationException("A reserva já está desativada.");
 
                 // Verifica se a reserva pode ser desativada (ex: não está finalizada)
-                if (existingReservation.Status?.ToLower() == "completed")
+                if (existingReservation.Status?.ToLower() == "finished")
                     throw new InvalidOperationException("Não é possível desativar uma reserva que já foi finalizada.");
 
                 // Chama o repository para desativar
@@ -263,8 +263,8 @@ namespace Viagium.Services
                 await _unitOfWork.ReservationRepository.UpdateAsync(deactivatedReservation);
                 await _unitOfWork.SaveAsync();
 
-                // ✅ NOVO: Atualizar o número de pessoas confirmadas após cancelar a reserva
-                await UpdateConfirmedPeopleCountAsync(deactivatedReservation.TravelPackageId);
+                // ✅ CORREÇÃO: Removido a chamada problemática que causa loop infinito
+                // await UpdateConfirmedPeopleCountAsync(deactivatedReservation.TravelPackageId);
 
                 return deactivatedReservation;
 


### PR DESCRIPTION
Removidas chamadas problemáticas para `UpdateConfirmedPeopleCountAsync` no `ReservationService.cs`, que causavam um loop infinito. A verificação do status da reserva foi alterada de "completed" para "finished" para melhor refletir seu estado. Comentários explicativos foram adicionados para esclarecer as correções realizadas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could cause an infinite loop when adding or deactivating reservations.
  * Improved status handling when deactivating reservations by updating the status check for finalized reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->